### PR TITLE
chore(merkle-trees): pin `compiler_version`

### DIFF
--- a/packages/merkle-trees/Nargo.toml
+++ b/packages/merkle-trees/Nargo.toml
@@ -2,3 +2,4 @@
 name = "merkle_trees"
 type = "lib"
 authors = ["fabianschu", "signorecello"]
+compiler_version = "0.26.0"


### PR DESCRIPTION
`nargo` version is already [pinned](https://github.com/privacy-scaling-explorations/zk-kit.noir/blob/bdc0cb03fc95784cbe737471ef1e463f94dd3f44/.github/workflows/tests.yml#L41) in the GH action workflow (see https://github.com/privacy-scaling-explorations/zk-kit/pull/256).
But not in the `Nargo.toml`.

With the latest version (that I was using) the tests will fail because of breaking changes in the std lib:
ex
```
error: Could not resolve 'HashPath' in path
   ┌─ /home/sripwoud/code/zk-kit/zk-kit.noir/packages/merkle-trees/src/merkle.nr:25:22
   │
25 │ impl Modifier<Field, HashPath> for MerkleTree {
   │                      --------
   │

error: cannot find `pedersen_hash_slice` in this scope
  ┌─ /home/sripwoud/code/zk-kit/zk-kit.noir/packages/merkle-trees/src/merkle/tests/pedersen.nr:5:5
  │
5 │     pedersen_hash_slice(leaves)
  │     ------------------- not found in this scope
```