### PR TITLE
chore(merkle-trees)!: update to match Noir 0.30.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,5 +42,5 @@ jobs:
       - uses: actions/checkout@v4
       - uses: noir-lang/noirup@v0.1.3
         with:
-          toolchain: 0.26.0
+          toolchain: 0.30.0
       - run: nargo test

--- a/packages/merkle-trees/Nargo.toml
+++ b/packages/merkle-trees/Nargo.toml
@@ -2,4 +2,4 @@
 name = "merkle_trees"
 type = "lib"
 authors = ["fabianschu", "signorecello"]
-compiler_version = "0.26.0"
+compiler_version = "0.30.0"

--- a/packages/merkle-trees/src/lib.nr
+++ b/packages/merkle-trees/src/lib.nr
@@ -7,15 +7,44 @@ trait Calculator<T> {
     fn calculate_two_roots(self, entry: T, siblings: (Field, [Field])) -> (Field, Field);
 }
 
-trait Creator {
-    fn default(root: Field, hasher: fn([Field]) -> Field) -> Self;
+trait SMT_Creator {
+    fn default(
+        root: Field,
+        leaf_hasher: fn([Field; 3]) -> Field,
+        hasher: fn([Field; 2]) -> Field,
+    ) -> Self;
 
     /**
      * Imports an existing Sparse Merkle Tree (SparseMerkleTree) instance.
      * @param hasher The hash function that is used to hash the nodes of the tree
      * @param root The root of the tree
      */
-    fn from(root: Field, hasher: fn([Field]) -> Field) -> Self {
+    fn from(
+        root: Field,
+        leaf_hasher: fn([Field; 3]) -> Field,
+        hasher: fn([Field; 2]) -> Field,
+    ) -> Self {
+        Self::default(root, leaf_hasher, hasher)
+    }
+
+    /**
+     * Creates a new Sparse Merkle Tree (SparseMerkleTree) instance.
+     * @param hasher The hash function that is used to hash the nodes of the tree
+     */
+    fn new(leaf_hasher: fn([Field; 3]) -> Field, hasher: fn([Field; 2]) -> Field) -> Self {
+        Self::from(0, leaf_hasher, hasher)
+    }
+}
+
+trait MT_Creator {
+    fn default(root: Field, hasher: fn([Field; 2]) -> Field) -> Self;
+
+    /**
+     * Imports an existing Sparse Merkle Tree (SparseMerkleTree) instance.
+     * @param hasher The hash function that is used to hash the nodes of the tree
+     * @param root The root of the tree
+     */
+    fn from(root: Field, hasher: fn([Field; 2]) -> Field) -> Self {
         Self::default(root, hasher)
     }
 
@@ -23,7 +52,7 @@ trait Creator {
      * Creates a new Sparse Merkle Tree (SparseMerkleTree) instance.
      * @param hasher The hash function that is used to hash the nodes of the tree
      */
-    fn new(hasher: fn([Field]) -> Field) -> Self {
+    fn new(hasher: fn([Field; 2]) -> Field) -> Self {
         Self::from(0, hasher)
     }
 }

--- a/packages/merkle-trees/src/merkle.nr
+++ b/packages/merkle-trees/src/merkle.nr
@@ -1,15 +1,15 @@
-use crate::{Creator, MembershipProver, Modifier, NonMembershipProver};
+use crate::{MT_Creator, MembershipProver, Modifier, NonMembershipProver};
 
 mod tests;
 mod tree;
 
 struct MerkleTree {
-    hasher: fn([Field]) -> Field,
+    hasher: fn([Field; 2]) -> Field,
     root: Field,
 }
 
-impl Creator for MerkleTree {
-    fn default(root: Field, hasher: fn([Field]) -> Field) -> Self {
+impl MT_Creator for MerkleTree {
+    fn default(root: Field, hasher: fn([Field; 2]) -> Field) -> Self {
         Self { root, hasher }
     }
 }
@@ -45,11 +45,11 @@ impl Modifier<Field, HashPath> for MerkleTree {
             let sibling = siblings.1[i];
             if sibling != 0 {
                 if index_bits[i] == 0 {
-                    new_parent = (self.hasher)(&[new_parent, sibling]);
-                    old_parent = (self.hasher)(&[old_parent, sibling]);
+                    new_parent = (self.hasher)([new_parent, sibling]);
+                    old_parent = (self.hasher)([old_parent, sibling]);
                 } else {
-                    new_parent = (self.hasher)(&[sibling, new_parent]);
-                    old_parent = (self.hasher)(&[sibling, old_parent]);
+                    new_parent = (self.hasher)([sibling, new_parent]);
+                    old_parent = (self.hasher)([sibling, old_parent]);
                 }
             }
         }

--- a/packages/merkle-trees/src/merkle/tests/pedersen.nr
+++ b/packages/merkle-trees/src/merkle/tests/pedersen.nr
@@ -1,8 +1,8 @@
 use crate::merkle::MerkleTree;
-use dep::std::hash::pedersen::pedersen_hash_slice;
+use dep::std::hash::pedersen_hash;
 
-fn pedersen_hasher(leaves: [Field]) -> Field {
-    pedersen_hash_slice(leaves)
+fn pedersen_hasher(leaves: [Field; 2]) -> Field {
+    pedersen_hash(leaves)
 }
 
 #[test]
@@ -67,7 +67,7 @@ fn test_merkle_tree_update() {
 
     assert(
         mt.root
-            == pedersen_hasher(&[
+            == pedersen_hasher([
                 0xd98561fb02ca04d00801dfdc118b2a24cea0351963587712a28d368041370e1,
                 0x1c59022dba1d97f63021cc5a23e4fe80f019465e0ccb54de9aa91935495354a3,
             ]),

--- a/packages/merkle-trees/src/merkle/tests/poseidon.nr
+++ b/packages/merkle-trees/src/merkle/tests/poseidon.nr
@@ -1,12 +1,8 @@
 use crate::merkle::MerkleTree;
-use dep::std::hash::poseidon::bn254::{hash_2, hash_3};
+use dep::std::hash::poseidon::bn254::hash_2;
 
-fn poseidon_hasher(leaves: [Field]) -> Field {
-    if leaves.len() == 2 {
-        hash_2([leaves[0], leaves[1]])
-    } else {
-        hash_3([leaves[0], leaves[1], leaves[2]])
-    }
+fn poseidon_hasher(leaves: [Field; 2]) -> Field {
+    hash_2([leaves[0], leaves[1]])
 }
 
 #[test]
@@ -70,7 +66,7 @@ fn test_merkle_tree_update() {
 
     assert(
         mt.root
-            == poseidon_hasher(&[
+            == poseidon_hasher([
                 0xd98561fb02ca04d00801dfdc118b2a24cea0351963587712a28d368041370e1,
                 0x1910f234d14bea7c640841c9fd0d765e8599a4cd527285590e4159e66b912be1,
             ]),

--- a/packages/merkle-trees/src/merkle/tests/poseidon2.nr
+++ b/packages/merkle-trees/src/merkle/tests/poseidon2.nr
@@ -1,12 +1,8 @@
 use crate::merkle::MerkleTree;
 use dep::std::hash::poseidon2::Poseidon2::hash;
 
-fn poseidon2_hasher(leaves: [Field]) -> Field {
-    if leaves.len() == 2 {
-        hash([leaves[0], leaves[1]], 2)
-    } else {
-        hash([leaves[0], leaves[1], leaves[2]], 3)
-    }
+fn poseidon2_hasher(leaves: [Field; 2]) -> Field {
+    hash([leaves[0], leaves[1]], 2)
 }
 
 #[test]
@@ -72,7 +68,7 @@ fn test_merkle_tree_update() {
 
     assert(
         mt.root
-            == poseidon2_hasher(&[
+            == poseidon2_hasher([
                 0xd98561fb02ca04d00801dfdc118b2a24cea0351963587712a28d368041370e1,
                 0x21447efbbddb57d6fc5ad24d906388492e82c44e5160425258dd4ea995e3a06e,
             ]),

--- a/packages/merkle-trees/src/merkle/tree.nr
+++ b/packages/merkle-trees/src/merkle/tree.nr
@@ -24,7 +24,7 @@ impl Calculator<Field> for MerkleTree {
                     left = node;
                     right = sibling;
                 }
-                node = (self.hasher)(&[left, right]);
+                node = (self.hasher)([left, right]);
             }
         }
         node
@@ -54,15 +54,15 @@ impl Calculator<Field> for MerkleTree {
                 }
 
                 if (index_bits[i] == 0) {
-                    root_with_leaf = (self.hasher)(&[root_with_leaf, sibling]);
+                    root_with_leaf = (self.hasher)([root_with_leaf, sibling]);
 
                     if (root_without_leaf != sibling) {
-                        root_without_leaf = (self.hasher)(&[root_without_leaf, sibling]);
+                        root_without_leaf = (self.hasher)([root_without_leaf, sibling]);
                     }
                 } else {
-                    root_with_leaf = (self.hasher)(&[sibling, root_with_leaf]);
+                    root_with_leaf = (self.hasher)([sibling, root_with_leaf]);
                     if (root_without_leaf != sibling) {
-                        root_without_leaf = (self.hasher)(&[sibling, root_without_leaf]);
+                        root_without_leaf = (self.hasher)([sibling, root_without_leaf]);
                     }
                 };
             }

--- a/packages/merkle-trees/src/sparse_merkle.nr
+++ b/packages/merkle-trees/src/sparse_merkle.nr
@@ -1,16 +1,25 @@
-use crate::{Creator, MembershipProver, Modifier, NonMembershipProver};
+use crate::{MembershipProver, Modifier, NonMembershipProver, SMT_Creator};
 
 mod tests;
 mod tree;
 
 struct SparseMerkleTree {
     root: Field,
-    hasher: fn([Field]) -> Field,
+    leaf_hasher: fn([Field; 3]) -> Field,
+    hasher: fn([Field; 2]) -> Field,
 }
 
-impl Creator for SparseMerkleTree {
-    fn default(root: Field, hasher: fn([Field]) -> Field) -> Self {
-        Self { root, hasher }
+impl SMT_Creator for SparseMerkleTree {
+    fn default(
+        root: Field,
+        leaf_hasher: fn([Field; 3]) -> Field,
+        hasher: fn([Field; 2]) -> Field,
+    ) -> Self {
+        Self {
+            root,
+            leaf_hasher,
+            hasher,
+        }
     }
 }
 
@@ -50,7 +59,7 @@ impl Modifier<(Field, Field), [Field]> for SparseMerkleTree {
         // otherwise the correctness of the old root is validated based on the siblings after which
         // the new root is calculated and returned
         if (self.root == 0) {
-            self.root = (self.hasher)(&[new_entry.0, new_entry.1, 1]);
+            self.root = (self.leaf_hasher)([new_entry.0, new_entry.1, 1]);
         } else {
             let (old, new) = self.calculate_two_roots(new_entry, (new_entry.0, siblings));
             assert(old == self.root);
@@ -72,9 +81,9 @@ impl Modifier<(Field, Field), [Field]> for SparseMerkleTree {
         let path = key.to_be_bits(siblings.len() as u32);
 
         // old_parent is a container to temporarily store the nodes that ultimately lead to the OLD root
-        let mut old_parent: Field = (self.hasher)(&[key, old_value, 1]);
+        let mut old_parent: Field = (self.leaf_hasher)([key, old_value, 1]);
         // new_parent is a container to temporarily store the nodes that ultimately lead to the NEW root
-        let mut new_parent: Field = (self.hasher)(&[key, new_value, 1]);
+        let mut new_parent: Field = (self.leaf_hasher)([key, new_value, 1]);
         // starting from the bottom of the tree, for each level it checks whether there is a sibling and if
         // that is the case, it hashes the two containers with the sibling and updates the containers with the
         // resulting hashes until the uppermost level is reached aka the root node
@@ -82,11 +91,11 @@ impl Modifier<(Field, Field), [Field]> for SparseMerkleTree {
             let sibling = siblings[i];
             if sibling != 0 {
                 if path[i] == 0 {
-                    new_parent = (self.hasher)(&[new_parent, sibling]);
-                    old_parent = (self.hasher)(&[old_parent, sibling]);
+                    new_parent = (self.hasher)([new_parent, sibling]);
+                    old_parent = (self.hasher)([old_parent, sibling]);
                 } else {
-                    new_parent = (self.hasher)(&[sibling, new_parent]);
-                    old_parent = (self.hasher)(&[sibling, old_parent]);
+                    new_parent = (self.hasher)([sibling, new_parent]);
+                    old_parent = (self.hasher)([sibling, old_parent]);
                 }
             }
         }

--- a/packages/merkle-trees/src/sparse_merkle/tests/pedersen.nr
+++ b/packages/merkle-trees/src/sparse_merkle/tests/pedersen.nr
@@ -1,15 +1,19 @@
 use crate::globals::TREE_DEPTH;
 use crate::sparse_merkle::SparseMerkleTree;
-use dep::std::hash::pedersen_hash_slice;
+use dep::std::hash::pedersen_hash;
 
-fn pedersen_hasher(leaves: [Field]) -> Field {
-    pedersen_hash_slice(leaves)
+fn pedersen_hasher(leaves: [Field; 2]) -> Field {
+    pedersen_hash(leaves)
+}
+
+fn leaf_pedersen_hasher(leaves: [Field; 3]) -> Field {
+    pedersen_hash(leaves)
 }
 
 #[test]
 fn test_verify_membership_proof() {
     let root = 10163036226218365628416274178218539053881692695713984759452839539868301499377;
-    let smt = SparseMerkleTree::from(root, pedersen_hasher);
+    let smt = SparseMerkleTree::from(root, leaf_pedersen_hasher, pedersen_hasher);
 
     let key = 20438969296305830531522370305156029982566273432331621236661483041446048135547;
     let value = 17150136040889237739751319962368206600863150289695545292530539263327413090784;
@@ -25,7 +29,7 @@ fn test_verify_membership_proof() {
 #[test]
 fn test_verify_non_membership_proof() {
     let root = 10163036226218365628416274178218539053881692695713984759452839539868301499377;
-    let smt = SparseMerkleTree::from(root, pedersen_hasher);
+    let smt = SparseMerkleTree::from(root, leaf_pedersen_hasher, pedersen_hasher);
 
     let key = 20438969296305830531522380305156029982566273432331621236661483041446048135547;
     let value = 17150136040889237739751319962368206600863250289695545292530539263327413090784;
@@ -44,7 +48,7 @@ fn test_verify_non_membership_proof() {
 
 #[test]
 fn test_add_first_element() {
-    let mut smt = SparseMerkleTree::new(pedersen_hasher);
+    let mut smt = SparseMerkleTree::new(leaf_pedersen_hasher, pedersen_hasher);
 
     let key = 20438969296305830531522370305156029982566273432331621236661483041446048135547;
     let value = 17150136040889237739751319962368206600863150289695545292530539263327413090784;
@@ -60,7 +64,7 @@ fn test_add_first_element() {
 #[test]
 fn test_add_element_to_one_element_tree() {
     let root = 2422708535743783816563452741494007579003622904961533867614614610167375232032;
-    let mut smt = SparseMerkleTree::from(root, pedersen_hasher);
+    let mut smt = SparseMerkleTree::from(root, leaf_pedersen_hasher, pedersen_hasher);
 
     let key = 7374494214024125590767526270082639043919066776944047470878693145844636921798;
     let value = 3315292394704439116482935361251007857050519763420264982454883186141315324846;
@@ -77,7 +81,7 @@ fn test_add_element_to_one_element_tree() {
 #[test]
 fn test_add_element_to_existing_tree() {
     let root = 13995819305603022633355680906127521476353407789113491617487780281225566393218;
-    let mut smt = SparseMerkleTree::from(root, pedersen_hasher);
+    let mut smt = SparseMerkleTree::from(root, leaf_pedersen_hasher, pedersen_hasher);
 
     let key = 12467743582502009806452203915647380852106587605639139696405928234368558796420;
     let value = 7661601117049907361128926075270530269257730340678343102988736234309528818274;
@@ -95,7 +99,7 @@ fn test_add_element_to_existing_tree() {
 #[test]
 fn test_delete() {
     let root = 8307334591379324778417663235463648615723981385559143500721691536202573318888;
-    let mut smt = SparseMerkleTree::from(root, pedersen_hasher);
+    let mut smt = SparseMerkleTree::from(root, leaf_pedersen_hasher, pedersen_hasher);
 
     let key = 12467743582502009806452203915647380852106587605639139696405928234368558796420;
     let value = 7661601117049907361128926075270530269257730340678343102988736234309528818274;
@@ -113,7 +117,7 @@ fn test_delete() {
 #[test]
 fn test_update() {
     let root = 8307334591379324778417663235463648615723981385559143500721691536202573318888;
-    let mut smt = SparseMerkleTree::from(root, pedersen_hasher);
+    let mut smt = SparseMerkleTree::from(root, leaf_pedersen_hasher, pedersen_hasher);
 
     let key = 12467743582502009806452203915647380852106587605639139696405928234368558796420;
     let old_value = 7661601117049907361128926075270530269257730340678343102988736234309528818274;

--- a/packages/merkle-trees/src/sparse_merkle/tests/poseidon.nr
+++ b/packages/merkle-trees/src/sparse_merkle/tests/poseidon.nr
@@ -2,18 +2,18 @@ use crate::globals::TREE_DEPTH;
 use crate::sparse_merkle::SparseMerkleTree;
 use dep::std::hash::poseidon::bn254::{hash_2, hash_3};
 
-fn poseidon_hasher(leaves: [Field]) -> Field {
-    if leaves.len() == 2 {
-        hash_2([leaves[0], leaves[1]])
-    } else {
-        hash_3([leaves[0], leaves[1], leaves[2]])
-    }
+fn poseidon_hasher(leaves: [Field; 2]) -> Field {
+    hash_2([leaves[0], leaves[1]])
+}
+
+fn leaf_poseidon_hasher(leaves: [Field; 3]) -> Field {
+    hash_3([leaves[0], leaves[1], leaves[2]])
 }
 
 #[test]
 fn test_verify_membership_proof() {
     let root = 3532809757480436997969526334543526996242857122876262144596246439822675654128;
-    let smt = SparseMerkleTree::from(root, poseidon_hasher);
+    let smt = SparseMerkleTree::from(root, leaf_poseidon_hasher, poseidon_hasher);
 
     let key = 18746990989203767017840856832962652635369613415011636432610873672704085238844;
     let value = 10223238458026721676606706894638558676629446348345239719814856822628482567791;
@@ -28,7 +28,7 @@ fn test_verify_membership_proof() {
 #[test]
 fn test_verify_non_membership_proof() {
     let root = 3532809757480436997969526334543526996242857122876262144596246439822675654128;
-    let smt = SparseMerkleTree::from(root, poseidon_hasher);
+    let smt = SparseMerkleTree::from(root, leaf_poseidon_hasher, poseidon_hasher);
 
     let key = 8459688297517826598613412977307486050019239051864711035321718508109192087854;
     let value = 8510347201346963732943571140849185725417245763047403804445415726302354045170;
@@ -46,7 +46,7 @@ fn test_verify_non_membership_proof() {
 
 #[test]
 fn test_add_first_element() {
-    let mut smt = SparseMerkleTree::new(poseidon_hasher);
+    let mut smt = SparseMerkleTree::new(leaf_poseidon_hasher, poseidon_hasher);
 
     let key = 20438969296305830531522370305156029982566273432331621236661483041446048135547;
     let value = 17150136040889237739751319962368206600863150289695545292530539263327413090784;
@@ -62,7 +62,7 @@ fn test_add_first_element() {
 #[test]
 fn test_add_element_to_one_element_tree() {
     let root = 7842913321420301106140788486336995496832503825951977327575501561489697540557;
-    let mut smt = SparseMerkleTree::from(root, poseidon_hasher);
+    let mut smt = SparseMerkleTree::from(root, leaf_poseidon_hasher, poseidon_hasher);
 
     let key = 8459688297517826598613412977307486050019239051864711035321718508109192087854;
     let value = 8510347201346963732943571140849185725417245763047403804445415726302354045170;
@@ -79,7 +79,7 @@ fn test_add_element_to_one_element_tree() {
 #[test]
 fn test_add_element_to_existing_tree() {
     let root = 3532809757480436997969526334543526996242857122876262144596246439822675654128;
-    let mut smt = SparseMerkleTree::from(root, poseidon_hasher);
+    let mut smt = SparseMerkleTree::from(root, leaf_poseidon_hasher, poseidon_hasher);
 
     let key = 8459688297517826598613412977307486050019239051864711035321718508109192087854;
     let value = 8510347201346963732943571140849185725417245763047403804445415726302354045170;
@@ -98,7 +98,7 @@ fn test_add_element_to_existing_tree() {
 #[test]
 fn test_delete() {
     let root = 4657474665007910823901096287220097081233671466281873230928277896829046731272;
-    let mut smt = SparseMerkleTree::from(root, poseidon_hasher);
+    let mut smt = SparseMerkleTree::from(root, leaf_poseidon_hasher, poseidon_hasher);
 
     let key = 8459688297517826598613412977307486050019239051864711035321718508109192087854;
     let value = 8510347201346963732943571140849185725417245763047403804445415726302354045170;
@@ -117,7 +117,7 @@ fn test_delete() {
 #[test]
 fn test_update() {
     let root = 4202917944688591919039016743999516589372052081571553696755434379850460220435;
-    let mut smt = SparseMerkleTree::from(root, poseidon_hasher);
+    let mut smt = SparseMerkleTree::from(root, leaf_poseidon_hasher, poseidon_hasher);
 
     let key = 8459688297517826598613412977307486050019239051864711035321718508109192087854;
     let old_value = 8510347201346963732943571140849185725417245763047403804445415726302354045169;

--- a/packages/merkle-trees/src/sparse_merkle/tests/poseidon2.nr
+++ b/packages/merkle-trees/src/sparse_merkle/tests/poseidon2.nr
@@ -2,18 +2,18 @@ use crate::globals::TREE_DEPTH;
 use crate::sparse_merkle::SparseMerkleTree;
 use dep::std::hash::poseidon2::Poseidon2::hash;
 
-fn poseidon2_hasher(leaves: [Field]) -> Field {
-    if leaves.len() == 2 {
-        hash([leaves[0], leaves[1]], 2)
-    } else {
-        hash([leaves[0], leaves[1], leaves[2]], 3)
-    }
+fn poseidon2_hasher(leaves: [Field; 2]) -> Field {
+    hash([leaves[0], leaves[1]], 2)
+}
+
+fn leaf_poseidon2_hasher(leaves: [Field; 3]) -> Field {
+    hash([leaves[0], leaves[1], leaves[2]], 3)
 }
 
 #[test]
 fn test_verify_membership_proof() {
     let root = 10716768800230645516898989000381415039830058019558458336422156297954793868480;
-    let smt = SparseMerkleTree::from(root, poseidon2_hasher);
+    let smt = SparseMerkleTree::from(root, leaf_poseidon2_hasher, poseidon2_hasher);
 
     let key = 7374494214024125590767526270082639043919066776944047470878693145844636921798;
     let value = 3315292394704439116482935361251007857050519763420264982454883186141315324846;
@@ -28,7 +28,7 @@ fn test_verify_membership_proof() {
 #[test]
 fn test_verify_non_membership_proof() {
     let root = 7374500236777583547067945018169347524165767081414637328827735314573881617427;
-    let smt = SparseMerkleTree::from(root, poseidon2_hasher);
+    let smt = SparseMerkleTree::from(root, leaf_poseidon2_hasher, poseidon2_hasher);
 
     let key = 7374494214024125590767526270082639043919066776944047470878693145844636921798;
     let value = 10025543891561726230897112378978303079225878620021923798073814166479632519483;
@@ -46,7 +46,7 @@ fn test_verify_non_membership_proof() {
 
 #[test]
 fn test_add_first_element() {
-    let mut smt = SparseMerkleTree::new(poseidon2_hasher);
+    let mut smt = SparseMerkleTree::new(leaf_poseidon2_hasher, poseidon2_hasher);
 
     let key = 20438969296305830531522370305156029982566273432331621236661483041446048135547;
     let value = 17150136040889237739751319962368206600863150289695545292530539263327413090784;
@@ -62,7 +62,7 @@ fn test_add_first_element() {
 #[test]
 fn test_add_element_to_one_element_tree() {
     let root = 4234307959542627966802357671703046216228508835025652132690233312312451999811;
-    let mut smt = SparseMerkleTree::from(root, poseidon2_hasher);
+    let mut smt = SparseMerkleTree::from(root, leaf_poseidon2_hasher, poseidon2_hasher);
 
     let key = 7374494214024125590767526270082639043919066776944047470878693145844636921798;
     let value = 3315292394704439116482935361251007857050519763420264982454883186141315324846;
@@ -78,7 +78,7 @@ fn test_add_element_to_one_element_tree() {
 #[test]
 fn test_add_element_to_existing_tree() {
     let root = 20776251139619034284861007481547174315767321885984369040570901580313616282707;
-    let mut smt = SparseMerkleTree::from(root, poseidon2_hasher);
+    let mut smt = SparseMerkleTree::from(root, leaf_poseidon2_hasher, poseidon2_hasher);
 
     let key = 12467743582502009806452203915647380852106587605639139696405928234368558796420;
     let value = 7661601117049907361128926075270530269257730340678343102988736234309528818274;
@@ -96,7 +96,7 @@ fn test_add_element_to_existing_tree() {
 #[test]
 fn test_delete() {
     let root = 17243332362925384208896062537177789753675609853711705170581735815629040102816;
-    let mut smt = SparseMerkleTree::from(root, poseidon2_hasher);
+    let mut smt = SparseMerkleTree::from(root, leaf_poseidon2_hasher, poseidon2_hasher);
 
     let key = 12467743582502009806452203915647380852106587605639139696405928234368558796420;
     let value = 7661601117049907361128926075270530269257730340678343102988736234309528818274;
@@ -114,7 +114,7 @@ fn test_delete() {
 #[test]
 fn test_update() {
     let root = 17243332362925384208896062537177789753675609853711705170581735815629040102816;
-    let mut smt = SparseMerkleTree::from(root, poseidon2_hasher);
+    let mut smt = SparseMerkleTree::from(root, leaf_poseidon2_hasher, poseidon2_hasher);
 
     let key = 12467743582502009806452203915647380852106587605639139696405928234368558796420;
     let old_value = 7661601117049907361128926075270530269257730340678343102988736234309528818274;

--- a/packages/merkle-trees/src/sparse_merkle/tree.nr
+++ b/packages/merkle-trees/src/sparse_merkle/tree.nr
@@ -1,6 +1,6 @@
 use crate::sparse_merkle::SparseMerkleTree;
 use crate::Calculator;
-use dep::std::hash::pedersen_hash_slice;
+use dep::std::hash::pedersen_hash;
 
 impl Calculator<(Field, Field)> for SparseMerkleTree {
     /*
@@ -14,7 +14,7 @@ impl Calculator<(Field, Field)> for SparseMerkleTree {
         let index_bits = siblings.0.to_be_bits(siblings.1.len() as u32);
 
         // serves as container for hashes and is initialized to be the leaf node
-        let mut node = (self.hasher)(&[entry.0, entry.1, 1]);
+        let mut node = (self.leaf_hasher)([entry.0, entry.1, 1]);
         // iterates over the list of siblings until the first sibling is found
         // arbitrarily assigns the sibling to be the left and the node to be the
         // right element of the hashing pair unless the path indicates the opposite
@@ -29,7 +29,7 @@ impl Calculator<(Field, Field)> for SparseMerkleTree {
                     left = node;
                     right = sibling;
                 }
-                node = (self.hasher)(&[left, right]);
+                node = (self.hasher)([left, right]);
             }
         }
         node
@@ -53,7 +53,7 @@ impl Calculator<(Field, Field)> for SparseMerkleTree {
 
         // root_with_leaf is a container for hashes to derive the root node for the tree that
         // includes the entry
-        let mut root_with_leaf = (self.hasher)(&[entry.0, entry.1, 1]);
+        let mut root_with_leaf = (self.leaf_hasher)([entry.0, entry.1, 1]);
         // root_without_leaf is a container for hashes to derive the root node for the tree that
         // doesn't include the entry
         let mut root_without_leaf: Field = 0;
@@ -70,14 +70,14 @@ impl Calculator<(Field, Field)> for SparseMerkleTree {
                     root_without_leaf = siblings.1[i];
                 }
                 if index_bits[i] == 0 {
-                    root_with_leaf = (self.hasher)(&[root_with_leaf, sibling]);
+                    root_with_leaf = (self.hasher)([root_with_leaf, sibling]);
                     if (root_without_leaf != sibling) {
-                        root_without_leaf = (self.hasher)(&[root_without_leaf, sibling]);
+                        root_without_leaf = (self.hasher)([root_without_leaf, sibling]);
                     }
                 } else {
-                    root_with_leaf = (self.hasher)(&[sibling, root_with_leaf]);
+                    root_with_leaf = (self.hasher)([sibling, root_with_leaf]);
                     if (root_without_leaf != sibling) {
-                        root_without_leaf = (self.hasher)(&[sibling, root_without_leaf]);
+                        root_without_leaf = (self.hasher)([sibling, root_without_leaf]);
                     }
                 }
             }
@@ -91,7 +91,7 @@ fn test_hash_leaf_node() {
     let key = 20438969296305830531522370305156029982566273432331621236661483041446048135547;
     let value = 17150136040889237739751319962368206600863150289695545292530539263327413090784;
     assert(
-        pedersen_hash_slice(&[key, value, 1])
+        pedersen_hash([key, value, 1])
             == 0x055b34560562b842e236f919e9a74ee345d7523d70f711e0ccdb22466c767c20,
     );
 }
@@ -101,7 +101,7 @@ fn test_hash_node() {
     let left = 7374494214024125590767526270082639043919066776944047470878693145844636921798;
     let right = 3315292394704439116482935361251007857050519763420264982454883186141315324846;
     assert(
-        pedersen_hash_slice(&[left, right])
+        pedersen_hash([left, right])
             == 0x05f8a24a037ad8567c042c14c5a8299649e0fe13df1cec40d381a3671bae9245,
     );
 }


### PR DESCRIPTION
## Description

This change updates the MT library to match Noir 0.30.0. The relevant changes were related with the removal of the `_as_slice` methods as per [this PR](https://github.com/noir-lang/noir/pull/4675)

I reckon the solution isn't the most elegant, but time is of the essence in this particular situation and I understand this could definitely be iterated later on