### PR TITLE
fix `postinstall` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "check": "dprint check",
     "fmt": "dprint fmt",
-    "postinstall": "husky && git config --local core.editor cat",
+    "postinstall": "node_modules/husky/bin.mjs && git config --local core.editor cat",
     "test": "nargo test",
     "version:release": "changelogithub"
   },


### PR DESCRIPTION
In the [CI](https://github.com/privacy-scaling-explorations/zk-kit.noir/actions/runs/10560694113/job/29254955546?pr=8#step:4:36) and locally I see an error related to the husky postinstall script.

```
➤ YN0009: │ zk-kit.noir@workspace:. couldn't be built successfully (exit code 1, logs can be found here: /private/var/folders/vn/7xm7vmd962x2rg3whjzgp_7r0000gn/T/xfs-c35a9669/build.log)
```

and then log file shows
```
Usage Error: Couldn't find a script named "husky".
```

I am surprised because we are following the [official husky setup instructions](https://typicode.github.io/husky/how-to.html#manual-setup), aren't we?
