### PR TITLE
chore: use `noirfmt` to fmt `nr` files

### DIFF
--- a/.dprint.jsonc
+++ b/.dprint.jsonc
@@ -18,6 +18,6 @@
     "https://plugins.dprint.dev/markdown-0.17.8.wasm",
     "https://plugins.dprint.dev/typescript-0.93.2.wasm",
     "https://plugins.dprint.dev/toml-0.6.3.wasm",
-    "https://plugins.dprint.dev/g-plane/pretty_yaml-v0.5.0.wasm"
+    "https://plugins.dprint.dev/g-plane/pretty_yaml-v0.5.0.wasm",
   ],
 }

--- a/.dprint.jsonc
+++ b/.dprint.jsonc
@@ -1,13 +1,4 @@
 {
-  "exec": {
-    "commands": [{
-      "command": "rustfmt",
-      "exts": ["nr"],
-    }],
-  },
-  "prettier": {
-    "singleQuote": true,
-  },
   "typescript": {
     "quoteProps": "asNeeded",
     "quoteStyle": "preferSingle",
@@ -23,12 +14,10 @@
     "target/",
   ],
   "plugins": [
-    "https://plugins.dprint.dev/json-0.19.3.wasm",
-    "https://plugins.dprint.dev/markdown-0.17.1.wasm",
-    "https://plugins.dprint.dev/typescript-0.91.1.wasm",
-    "https://plugins.dprint.dev/exec-0.4.4.json@c207bf9b9a4ee1f0ecb75c594f774924baf62e8e53a2ce9d873816a408cecbf7",
-    "https://plugins.dprint.dev/toml-0.6.2.wasm",
-    // keep it last so that it is used only for exts that other plugins don't handle (yaml)
-    "https://plugins.dprint.dev/prettier-0.40.0.json@68c668863ec834d4be0f6f5ccaab415df75336a992aceb7eeeb14fdf096a9e9c",
+    "https://plugins.dprint.dev/json-0.19.4.wasm",
+    "https://plugins.dprint.dev/markdown-0.17.8.wasm",
+    "https://plugins.dprint.dev/typescript-0.93.2.wasm",
+    "https://plugins.dprint.dev/toml-0.6.3.wasm",
+    "https://plugins.dprint.dev/g-plane/pretty_yaml-v0.5.0.wasm"
   ],
 }

--- a/.github/ISSUE_TEMPLATE/---bug.md
+++ b/.github/ISSUE_TEMPLATE/---bug.md
@@ -4,7 +4,6 @@ about: Create a report to help us improve
 title: ''
 labels: "bug \U0001F41B"
 assignees: ''
-
 ---
 
 **Describe the bug**

--- a/.github/ISSUE_TEMPLATE/---circuit.md
+++ b/.github/ISSUE_TEMPLATE/---circuit.md
@@ -4,7 +4,6 @@ about: Propose a new ZK-kit Noir circuit
 title: ''
 labels: 'feature :rocket:'
 assignees: ''
-
 ---
 
 **Describe the package you'd like**

--- a/.github/ISSUE_TEMPLATE/---feature.md
+++ b/.github/ISSUE_TEMPLATE/---feature.md
@@ -4,7 +4,6 @@ about: Suggest an idea for ZK-Kit
 title: ''
 labels: 'feature :rocket:'
 assignees: ''
-
 ---
 
 **Is your feature request related to a problem? Please describe.**

--- a/.github/ISSUE_TEMPLATE/---refactoring.md
+++ b/.github/ISSUE_TEMPLATE/---refactoring.md
@@ -4,7 +4,6 @@ about: Suggest any improvements for this project
 title: ''
 labels: 'refactoring :recycle:'
 assignees: ''
-
 ---
 
 **Describe the improvement you're thinking about**

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,6 +31,9 @@ jobs:
         with:
           node-version: 20
           cache: yarn
+      - uses: noir-lang/noirup@v0.1.3
+        with:
+          toolchain: 0.36.0
       - run: yarn
       - run: yarn check
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ permissions:
 on:
   push:
     tags:
-      - '*'
+      - "*"
 
 jobs:
   release:
@@ -22,7 +22,7 @@ jobs:
         with:
           node-version: 20
           cache: yarn
-          registry-url: 'https://registry.npmjs.org'
+          registry-url: "https://registry.npmjs.org"
 
       - name: Authentication
         run: |

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "bugs": "https://github.com/privacy-scaling-explorations/zk-kit.noir/issues",
   "private": true,
   "scripts": {
-    "check": "dprint check",
-    "fmt": "dprint fmt",
+    "check": "concurrently -c auto -n dprint,noirfmt 'dprint check' 'nargo fmt --check'",
+    "fmt": "concurrently -c auto -n dprint,noirfmt 'dprint fmt' 'nargo fmt'",
     "postinstall": "husky && git config --local core.editor cat",
     "build": "nargo compile",
     "test": "npm run build && mocha && nargo test --workspace",
@@ -35,6 +35,7 @@
     "@types/mocha": "^10",
     "chai": "^4.5.0",
     "changelogithub": "patch:changelogithub@npm%3A0.13.3#~/.yarn/patches/changelogithub-npm-0.13.3-1783949906.patch",
+    "concurrently": "^9.1.0",
     "czg": "^1.9.1",
     "dprint": "^0.46.3",
     "husky": "^9.0.11",

--- a/packages/ecdh/tests/ecdh.test.ts
+++ b/packages/ecdh/tests/ecdh.test.ts
@@ -1,45 +1,45 @@
-import { BarretenbergBackend } from "@noir-lang/backend_barretenberg"
-import { Noir } from "@noir-lang/noir_js"
-import { ProofData } from "@noir-lang/types"
-import { expect } from "chai"
-import { randomBytes } from "crypto"
-import { readFileSync } from "fs"
-import { resolve } from "path"
-import "mocha"
+import { BarretenbergBackend } from '@noir-lang/backend_barretenberg'
+import { Noir } from '@noir-lang/noir_js'
+import { ProofData } from '@noir-lang/types'
+import { expect } from 'chai'
+import { randomBytes } from 'crypto'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import 'mocha'
 
 function generatePrivateKey(): Uint8Array {
-    return randomBytes(32)
+  return randomBytes(32)
 }
 
-describe("ECDH Circuit Tests", function () {
-    let noir: Noir
-    let backend: BarretenbergBackend
-    let correctProof: ProofData
+describe('ECDH Circuit Tests', function() {
+  let noir: Noir
+  let backend: BarretenbergBackend
+  let correctProof: ProofData
 
-    beforeEach(async () => {
-        const circuitFile = readFileSync(resolve(__dirname, "../../../target/ecdh.json"), "utf-8")
-        const circuit = JSON.parse(circuitFile)
-        backend = new BarretenbergBackend(circuit)
-        noir = new Noir(circuit, backend)
-        const pk1 = generatePrivateKey()
-        const pk2 = generatePrivateKey()
+  beforeEach(async () => {
+    const circuitFile = readFileSync(resolve(__dirname, '../../../target/ecdh.json'), 'utf-8')
+    const circuit = JSON.parse(circuitFile)
+    backend = new BarretenbergBackend(circuit)
+    noir = new Noir(circuit, backend)
+    const pk1 = generatePrivateKey()
+    const pk2 = generatePrivateKey()
 
-        // Convert Uint8Array to regular arrays
-        const input = {
-            private_key1: Array.from(pk1),
-            private_key2: Array.from(pk2)
-        }
+    // Convert Uint8Array to regular arrays
+    const input = {
+      private_key1: Array.from(pk1),
+      private_key2: Array.from(pk2),
+    }
 
-        correctProof = await noir.generateProof(input)
-    })
+    correctProof = await noir.generateProof(input)
+  })
 
-    it("Should generate valid proof for correct input", async function () {
-        expect(correctProof.proof).to.be.instanceOf(Uint8Array)
-    })
+  it('Should generate valid proof for correct input', async function() {
+    expect(correctProof.proof).to.be.instanceOf(Uint8Array)
+  })
 
-    it("Should verify valid proof for correct input", async function () {
-        expect(correctProof).to.not.be.undefined // Ensure proof is generated
-        const verification = await noir.verifyProof(correctProof)
-        expect(verification).to.be.true
-    })
+  it('Should verify valid proof for correct input', async function() {
+    expect(correctProof).to.not.be.undefined // Ensure proof is generated
+    const verification = await noir.verifyProof(correctProof)
+    expect(verification).to.be.true
+  })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -811,7 +811,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^4.1.0":
+"chalk@npm:^4.1.0, chalk@npm:^4.1.2":
   version: 4.1.2
   resolution: "chalk@npm:4.1.2"
   dependencies:
@@ -1048,6 +1048,24 @@ __metadata:
     array-ify: "npm:^1.0.0"
     dot-prop: "npm:^5.1.0"
   checksum: 10/fb71d70632baa1e93283cf9d80f30ac97f003aabee026e0b4426c9716678079ef5fea7519b84d012cbed938c476493866a38a79760564a9e21ae9433e40e6f0d
+  languageName: node
+  linkType: hard
+
+"concurrently@npm:^9.1.0":
+  version: 9.1.0
+  resolution: "concurrently@npm:9.1.0"
+  dependencies:
+    chalk: "npm:^4.1.2"
+    lodash: "npm:^4.17.21"
+    rxjs: "npm:^7.8.1"
+    shell-quote: "npm:^1.8.1"
+    supports-color: "npm:^8.1.1"
+    tree-kill: "npm:^1.2.2"
+    yargs: "npm:^17.7.2"
+  bin:
+    conc: dist/bin/concurrently.js
+    concurrently: dist/bin/concurrently.js
+  checksum: 10/9ed158095a6dcb30b2fbc00f173a993d080b6eca466b8005650b051f82618991ba8ae76b39c41ae78780f83846154e5ec434753f402aa4401acf0ffb2422e1cf
   languageName: node
   linkType: hard
 
@@ -2219,6 +2237,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lodash@npm:^4.17.21":
+  version: 4.17.21
+  resolution: "lodash@npm:4.17.21"
+  checksum: 10/c08619c038846ea6ac754abd6dd29d2568aa705feb69339e836dfa8d8b09abbb2f859371e86863eda41848221f9af43714491467b5b0299122431e202bb0c532
+  languageName: node
+  linkType: hard
+
 "log-symbols@npm:^4.1.0":
   version: 4.1.0
   resolution: "log-symbols@npm:4.1.0"
@@ -2943,6 +2968,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rxjs@npm:^7.8.1":
+  version: 7.8.1
+  resolution: "rxjs@npm:7.8.1"
+  dependencies:
+    tslib: "npm:^2.1.0"
+  checksum: 10/b10cac1a5258f885e9dd1b70d23c34daeb21b61222ee735d2ec40a8685bdca40429000703a44f0e638c27a684ac139e1c37e835d2a0dc16f6fc061a138ae3abb
+  languageName: node
+  linkType: hard
+
 "safe-buffer@npm:^5.1.0":
   version: 5.2.1
   resolution: "safe-buffer@npm:5.2.1"
@@ -2995,6 +3029,13 @@ __metadata:
   version: 3.0.0
   resolution: "shebang-regex@npm:3.0.0"
   checksum: 10/1a2bcae50de99034fcd92ad4212d8e01eedf52c7ec7830eedcf886622804fe36884278f2be8be0ea5fde3fd1c23911643a4e0f726c8685b61871c8908af01222
+  languageName: node
+  linkType: hard
+
+"shell-quote@npm:^1.8.1":
+  version: 1.8.1
+  resolution: "shell-quote@npm:1.8.1"
+  checksum: 10/af19ab5a1ec30cb4b2f91fd6df49a7442d5c4825a2e269b3712eded10eedd7f9efeaab96d57829880733fc55bcdd8e9b1d8589b4befb06667c731d08145e274d
   languageName: node
   linkType: hard
 
@@ -3240,6 +3281,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tree-kill@npm:^1.2.2":
+  version: 1.2.2
+  resolution: "tree-kill@npm:1.2.2"
+  bin:
+    tree-kill: cli.js
+  checksum: 10/49117f5f410d19c84b0464d29afb9642c863bc5ba40fcb9a245d474c6d5cc64d1b177a6e6713129eb346b40aebb9d4631d967517f9fbe8251c35b21b13cd96c7
+  languageName: node
+  linkType: hard
+
 "ts-node@npm:^10.9.2":
   version: 10.9.2
   resolution: "ts-node@npm:10.9.2"
@@ -3275,6 +3325,13 @@ __metadata:
     ts-node-transpile-only: dist/bin-transpile.js
     ts-script: dist/bin-script-deprecated.js
   checksum: 10/a91a15b3c9f76ac462f006fa88b6bfa528130dcfb849dd7ef7f9d640832ab681e235b8a2bc58ecde42f72851cc1d5d4e22c901b0c11aa51001ea1d395074b794
+  languageName: node
+  linkType: hard
+
+"tslib@npm:^2.1.0":
+  version: 2.8.1
+  resolution: "tslib@npm:2.8.1"
+  checksum: 10/3e2e043d5c2316461cb54e5c7fe02c30ef6dccb3384717ca22ae5c6b5bc95232a6241df19c622d9c73b809bea33b187f6dbc73030963e29950c2141bc32a79f7
   languageName: node
   linkType: hard
 
@@ -3498,7 +3555,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yargs@npm:^17.0.0":
+"yargs@npm:^17.0.0, yargs@npm:^17.7.2":
   version: 17.7.2
   resolution: "yargs@npm:17.7.2"
   dependencies:
@@ -3547,6 +3604,7 @@ __metadata:
     "@types/mocha": "npm:^10"
     chai: "npm:^4.5.0"
     changelogithub: "patch:changelogithub@npm%3A0.13.3#~/.yarn/patches/changelogithub-npm-0.13.3-1783949906.patch"
+    concurrently: "npm:^9.1.0"
     czg: "npm:^1.9.1"
     dprint: "npm:^0.46.3"
     husky: "npm:^9.0.11"


### PR DESCRIPTION
Follow up of https://github.com/privacy-scaling-explorations/zk-kit.noir/pull/19#issuecomment-2496656933

- do not use `rustfmt` with `dprint` `exec` plugin to format nargo files, use directyl `nargo fmt` instead.

not directly related to `noirfmt`, but related to `dprint` config
- remove `dprint` `prettier` plugin
- add `dprint` `pretty_yaml` plugin


note that unlike in #19, the `style` CI check now passes
