### PR TITLE
Typo fix Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ For commits it is recommended to use [Conventional Commits](https://www.conventi
 
 Don't worry if it looks complicated. In our repositories, `git commit` opens an interactive app to create your conventional commit.
 
-Each commit message consists of a **header**, a **body** and a **footer**. The **header** has a special format that includes a **type**, a **scope** and a **subject**:
+Each commit message consists of a **header**, an optional **body**, and a **footer**. The **header** has a special format that includes a **type**, a **scope** and a **subject**:
 
     <type>(<scope>): <subject>
     <BLANK LINE>


### PR DESCRIPTION
**Description:**

This pull request addresses an ambiguity in the "Commits rules" section of the contributing guide, specifically in the description of commit message structure.

### Problem:
The original text states:
```
Each commit message consists of a **header**, a **body** and a **footer**.
```
This statement implies that the **body** is a mandatory part of a commit message, which is not accurate. In reality, the **body** is optional, and not all commits will require a body.

### Solution:
The wording has been updated to:
```
Each commit message consists of a **header**, an optional **body**, and a **footer**.
```
This clarification ensures that contributors understand the **body** is not required for every commit and prevents confusion.

### Importance:
Clarifying that the **body** is optional helps contributors avoid unnecessary commits with empty bodies. This improves the clarity and consistency of the commit history, which is especially important for automated changelog generation and code review processes.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have run `yarn test` without getting any errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
