### PR TITLE
docs: Fixed broken link in documentation in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@
 | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 
 > [!IMPORTANT]\
-> Installation of [Nargo](https://noir-lang.org/getting_started/nargo_installation) required for circuit tests.
+> Installation of [Nargo](https://noir-lang.org/docs/getting_started/noir_installation) required for circuit tests.
 
 ## 🗂️ Repositories
 


### PR DESCRIPTION
## Description

I replaced the broken link with the correct one: [https://noir-lang.org/docs/getting_started/noir_installation](https://noir-lang.org/docs/getting_started/noir_installation).

## Checklist

-   [x] I have read and understand the [contributor guidelines](https://github.com/privacy-scaling-explorations/zk-kit.noir/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/privacy-scaling-explorations/zk-kit.noir/blob/main/CODE_OF_CONDUCT.md).
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings
-   [x] I have run `yarn style` without getting any errors
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
