### PR TITLE
Bump noir version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
                   bun-version: latest
             - uses: noir-lang/noirup@v0.1.3
               with:
-                  toolchain: 0.39.0
+                  toolchain: 1.0.0-beta.1
             - run: bun i
             - run: bun fmt
 
@@ -44,5 +44,5 @@ jobs:
             - uses: actions/checkout@v4
             - uses: noir-lang/noirup@v0.1.3
               with:
-                  toolchain: 0.39.0
+                  toolchain: 1.0.0-beta.1
             - run: nargo test

--- a/packages/ecdh/Nargo.toml
+++ b/packages/ecdh/Nargo.toml
@@ -2,7 +2,6 @@
 name = "ecdh"
 type = "bin"
 authors = ["YashBit"]
-compiler_version = ">=0.39.0"
 
 [dependencies]
 ec = { tag = "v0.1.2", git = "https://github.com/noir-lang/ec" }

--- a/packages/merkle-trees/Nargo.toml
+++ b/packages/merkle-trees/Nargo.toml
@@ -2,4 +2,3 @@
 name = "merkle_trees"
 type = "lib"
 authors = ["fabianschu", "signorecello"]
-compiler_version = ">=0.39.0"

--- a/tests/Nargo.toml
+++ b/tests/Nargo.toml
@@ -2,7 +2,6 @@
 name = "merkle_trees"
 type = "lib"
 authors = ["fabianschu", "signorecello"]
-compiler_version = ">=0.39.0"
 
 [dependencies]
 bignum = { git = "https://github.com/noir-lang/noir-bignum", tag = "zpedro/default_trait" }


### PR DESCRIPTION
Bumping to 1.0.0-beta.1 as required by the bigint/bigcurve lib. Removed the compiler versions in Nargo.toml as the bottleneck is almost always downstream