### PR TITLE
refactor: remove debug prints and improve hash path condition

### DIFF
--- a/packages/merkle-trees/src/sparse_merkle.nr
+++ b/packages/merkle-trees/src/sparse_merkle.nr
@@ -126,7 +126,6 @@ where
 
         // serves as container for hashes and is initialized to be the leaf node
         let mut node = (self.leaf_hasher)([entry.0, entry.1, T::default()]);
-        println(node);
         // iterates over the list of siblings until the first sibling is found
         // arbitrarily assigns the sibling to be the left and the node to be the
         // right element of the hashing pair unless the path indicates the opposite
@@ -141,11 +140,9 @@ where
                     left = node;
                     right = sibling;
                 }
-                println(f"left {left} right {right}");
                 node = (self.hasher)([left, right]);
             }
         }
-        println(f"root {node}");
         node
     }
 
@@ -181,7 +178,7 @@ where
             // and starting from each SUBSEQUENT iteration it is hashed with its sibling and the resulting hash
             // again stored in the container until the root is reached
             if sibling != T::default() {
-                if hash_path[i - 1] == T::default() {
+                if (i > 0) & (hash_path[i - 1] == T::default()) {
                     root_without_leaf = hash_path[i];
                 }
 


### PR DESCRIPTION
<!-- Please refer to our CONTRIBUTING documentation for any questions on submitting a pull request. -->
<!-- Provide a general summary of your changes in the Title above. -->

## Description

Idk if you accept PR's like this but thought may be some clean up would be useful for you, sorry if not

- Added i > 0 check before accessing hash_path[i - 1].
- Cleaned up unnecessary debug output.

## Checklist

<!-- Please check if the PR fulfills these requirements. -->

- [ ] I have read and understand the [contributor guidelines](https://github.com/privacy-scaling-explorations/zk-kit.noir/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/privacy-scaling-explorations/zk-kit.noir/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have run `bun check` without getting any errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

> [!IMPORTANT]
> We do not accept pull requests for minor grammatical fixes (e.g., correcting typos, rewording sentences) or for fixing broken links, unless they significantly improve clarity or functionality. These contributions, while appreciated, are not a priority for merging. If you notice any of these issues, please create a [GitHub Issue](https://github.com/privacy-scaling-explorations/zk-kit.noir/issues/new?template=BLANK_ISSUE) to report them so they can be properly tracked and addressed.
