### PR TITLE
fix: correct root_without_leaf initialization in SparseMerkleTree.calculate_two_roots

### DIFF
--- a/packages/merkle-trees/src/sparse_merkle.nr
+++ b/packages/merkle-trees/src/sparse_merkle.nr
@@ -177,11 +177,10 @@ where
             // To calc the root node that doesn't include entry, the first sibling is put into the container
             // and starting from each SUBSEQUENT iteration it is hashed with its sibling and the resulting hash
             // again stored in the container until the root is reached
+            if i == 0 {
+                root_without_leaf = hash_path[i];
+            }
             if sibling != T::default() {
-                if (i > 0) & (hash_path[i - 1] == T::default()) {
-                    root_without_leaf = hash_path[i];
-                }
-
                 if index_bits[i] != 0 {
                     root_with_leaf = (self.hasher)([sibling, root_with_leaf]);
                     if (root_without_leaf != sibling) {


### PR DESCRIPTION
Fix error in calculate_two_roots method where root_without_leaf initialization
was using incorrect conditional logic.

Changes:
- Replace complex condition (i > 0) & (hash_path[i-1] == T::default()) with simple i == 0
- Ensures root_without_leaf is always properly initialized with first sibling value
- Aligns SparseMerkleTree logic with regular MerkleTree implementation
- Fixes potential edge cases where root_without_leaf could remain T::default()

This fix ensures correct calculation of tree root without leaf in all scenarios,
preventing incorrect tree state computations during add/delete operations.