### PR TITLE
Add depth <= MAX_DEPTH assertion to binary_merkle_root

### DIFF
--- a/packages/binary-merkle-root/src/lib.nr
+++ b/packages/binary-merkle-root/src/lib.nr
@@ -17,6 +17,9 @@ pub fn binary_merkle_root<let MAX_DEPTH: u32>(
     // Start from the leaf node
     let mut node = leaf;
 
+    // Validate that the provided depth does not exceed the static MAX_DEPTH
+    assert(depth <= MAX_DEPTH);
+
     // Iterate through the Merkle proof up to MAX_DEPTH
     for i in 0..MAX_DEPTH {
         // Only compute hash if the current level is within the tree depth


### PR DESCRIPTION
Enforces an explicit bound on the dynamic proof length to prevent silent truncation when depth exceeds MAX_DEPTH. This ensures invalid or overly long proofs fail fast, aligning with repository patterns where claimed sizes/heights are validated and with tests that assume zero-padding beyond depth.