### PR TITLE
refactor(scripts): add positional commit argument to version:tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,32 @@ bun run test
 1. Create a new git tag:
 
 ```bash
-bun version:tag <package-name> <version>
-# e.g. bun version:tag merkle-trees 0.0.1
+bun run version:tag <package-name> <version> [commit] [options]
+# e.g. bun run version:tag merkle-trees 0.0.1
+```
+
+**Arguments:**
+
+- `commit` - (optional) Commit SHA or ref to tag (default: HEAD)
+
+**Options:**
+
+- `--commit, -c <ref>` - Tag a specific commit (alternative to positional)
+- `--force, -f` - Overwrite an existing tag
+- `--help, -h` - Show help
+
+**Examples:**
+
+```bash
+# Tag HEAD (default)
+bun run version:tag merkle-trees 1.0.0
+
+# Tag a specific commit (useful for multi-package releases)
+bun run version:tag merkle-trees 1.0.0 abc123
+bun run version:tag ecdh 2.0.0 abc123
+
+# Overwrite an existing tag
+bun run version:tag merkle-trees 1.0.0 --force
 ```
 
 2. Push the new git tag:

--- a/scripts/create-tag.ts
+++ b/scripts/create-tag.ts
@@ -1,17 +1,187 @@
 import { execSync } from 'child_process'
+import { readdirSync, statSync } from 'fs'
+import { join } from 'path'
 
-const packageName = process.argv[2]
-const version = process.argv[3]
+interface Options {
+  commit: string
+  force: boolean
+}
 
-if (!packageName || !version) {
+function showHelp(): void {
+  console.log(`
+Usage: bun run version:tag <package> <version> [commit] [options]
+
+Create a git tag for a package release.
+
+Arguments:
+  package               Package name (must exist in packages/)
+  version               Version number (semver format: X.Y.Z)
+  commit                Commit SHA or ref to tag (default: HEAD)
+
+Options:
+  --commit, -c <ref>    Commit SHA or ref to tag (alternative to positional)
+  --force, -f           Force overwrite existing tag
+  --help, -h            Show this help message
+
+Examples:
+  bun run version:tag merkle-trees 1.0.0
+  bun run version:tag merkle-trees 1.0.0 abc123
+  bun run version:tag ecdh 2.0.0 abc123
+  bun run version:tag merkle-trees 1.0.0 --commit abc123
+  bun run version:tag merkle-trees 1.0.0 --force
+`)
+}
+
+function getValidPackages(): string[] {
+  const packagesDir = join(process.cwd(), 'packages')
+  try {
+    return readdirSync(packagesDir).filter((name) => {
+      const fullPath = join(packagesDir, name)
+      return statSync(fullPath).isDirectory() && !name.startsWith('.')
+    })
+  } catch {
+    console.error('❌ Could not read packages directory')
+    process.exit(1)
+  }
+}
+
+function isValidVersion(version: string): boolean {
+  // Semver pattern: X.Y.Z with optional prerelease and metadata
+  const semverPattern = /^\d+\.\d+\.\d+(-[a-zA-Z0-9.-]+)?(\+[a-zA-Z0-9.-]+)?$/
+  return semverPattern.test(version)
+}
+
+function isValidCommitRef(ref: string): boolean {
+  try {
+    execSync(`git rev-parse --verify ${ref}`, { stdio: 'pipe' })
+    return true
+  } catch {
+    return false
+  }
+}
+
+function tagExists(tagName: string): boolean {
+  try {
+    execSync(`git rev-parse --verify refs/tags/${tagName}`, { stdio: 'pipe' })
+    return true
+  } catch {
+    return false
+  }
+}
+
+function parseArgs(args: string[]): { packageName: string; version: string; options: Options } | null {
+  const options: Options = {
+    commit: 'HEAD',
+    force: false,
+  }
+
+  let packageName = ''
+  let version = ''
+  let commitFlagUsed = false
+  const positionalArgs: string[] = []
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i]
+
+    if (arg === '--help' || arg === '-h') {
+      showHelp()
+      process.exit(0)
+    } else if (arg === '--force' || arg === '-f')
+      options.force = true
+    else if (arg === '--commit' || arg === '-c') {
+      const nextArg = args[++i]
+      if (!nextArg) {
+        console.error('❌ --commit requires a value')
+        process.exit(1)
+      }
+      options.commit = nextArg
+      commitFlagUsed = true
+    } else if (arg.startsWith('-')) {
+      console.error(`❌ Unknown option: ${arg}`)
+      showHelp()
+      process.exit(1)
+    } else {
+      positionalArgs.push(arg)
+    }
+  }
+
+  if (positionalArgs.length < 2)
+    return null
+
+  packageName = positionalArgs[0]
+  version = positionalArgs[1]
+
+  // Use 3rd positional argument as commit ref if --commit flag wasn't used
+  if (positionalArgs.length >= 3 && !commitFlagUsed)
+    options.commit = positionalArgs[2]
+
+  return { packageName, version, options }
+}
+
+// Main execution
+const args = process.argv.slice(2)
+
+// Handle --help with no args
+if (args.length === 0 || args.includes('--help') || args.includes('-h')) {
+  showHelp()
+  process.exit(args.length === 0 ? 1 : 0)
+}
+
+const parsed = parseArgs(args)
+
+if (!parsed) {
   console.error('❌ Please provide a package name and version')
+  showHelp()
   process.exit(1)
 }
 
+const { packageName, version, options } = parsed
+
+// Validate package name
+const validPackages = getValidPackages()
+if (!validPackages.includes(packageName)) {
+  console.error(`❌ Invalid package: "${packageName}"`)
+  console.error(`   Valid packages: ${validPackages.join(', ')}`)
+  process.exit(1)
+}
+
+// Validate version format
+if (!isValidVersion(version)) {
+  console.error(`❌ Invalid version format: "${version}"`)
+  console.error('   Expected semver format: X.Y.Z (e.g., 1.0.0, 2.1.3-beta.1)')
+  process.exit(1)
+}
+
+// Validate commit reference
+if (!isValidCommitRef(options.commit)) {
+  console.error(`❌ Invalid commit reference: "${options.commit}"`)
+  process.exit(1)
+}
+
+const tagName = `${packageName}-v${version}`
+
+// Check if tag already exists
+if (tagExists(tagName)) {
+  if (!options.force) {
+    console.error(`❌ Tag "${tagName}" already exists`)
+    console.error('   Use --force to overwrite the existing tag')
+    process.exit(1)
+  }
+  // Delete existing tag if force is enabled
+  try {
+    execSync(`git tag -d ${tagName}`, { stdio: 'pipe' })
+  } catch {
+    console.error(`❌ Failed to delete existing tag "${tagName}"`)
+    process.exit(1)
+  }
+}
+
+// Create the tag
 try {
-  execSync(`git tag ${packageName}-v${version}`, { stdio: 'inherit' })
-  console.log(`✅ Created git tag: ${packageName}-v${version}`)
+  execSync(`git tag ${tagName} ${options.commit}`, { stdio: 'inherit' })
+  const commitDisplay = options.commit === 'HEAD' ? 'HEAD' : options.commit.substring(0, 7)
+  console.log(`✅ Created git tag: ${tagName} (at ${commitDisplay})`)
 } catch (err) {
-  console.error('❌ Failed to create git tag', err)
+  console.error(`❌ Failed to create git tag "${tagName}"`, err)
   process.exit(1)
 }


### PR DESCRIPTION
## Description
  - Added optional 3rd positional argument for commit ref to `version:tag` script
  - Simplified tagging specific commits like `bun run version:tag merkle-trees 1.0.0 abc123`
  - Enhanced the CLI by adding help menu etc.
  - Updated README.md accordingly
 
## Related Issue(s)

Closes #68 

## Checklist

- [x] I have read and understand the [contributor guidelines](https://github.com/privacy-scaling-explorations/zk-kit.noir/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/privacy-scaling-explorations/zk-kit.noir/blob/main/CODE_OF_CONDUCT.md).
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have run `bun check` without getting any errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

