### PR TITLE
[CRITICAL] Fix False Non-Membership Proofs,  missing key inequality check 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
           bun-version: latest
       - uses: noir-lang/noirup@v0.1.3
         with:
-          toolchain: 1.0.0-beta.9
+          toolchain: 1.0.0-beta.19
       - run: bun i
       - run: bun fmt
 
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: noir-lang/noirup@v0.1.3
         with:
-          toolchain: 1.0.0-beta.11
+          toolchain: 1.0.0-beta.19
 
       # As this is a library, we do not allow compiler warnings
       - run: nargo check --deny-warnings

--- a/packages/merkle-trees/src/sparse_merkle.nr
+++ b/packages/merkle-trees/src/sparse_merkle.nr
@@ -38,8 +38,17 @@ impl<T> NonMembershipProver<T, (T, T)> for SparseMerkleTree<T>
 where
     T: Eq + Default,
 {
-    fn non_membership<let N: u32>(self, matching_entry: (T, T), index: Field, siblings: [T; N]) {
+    fn non_membership<let N: u32>(
+        self,
+        matching_entry: (T, T),
+        queried_key: T,
+        index: Field,
+        siblings: [T; N],
+    ) {
         if (self.root != T::default()) {
+            // Ensure the matching entry's key is different from the queried key
+            assert(matching_entry.0 != queried_key);
+
             // non-membership proof: the root is calculated based on the matching_entry, the siblings
             // and the path that is determined by the key of entry. This makes sure that matching_entry is in fact
             // a matching entry for entry meaning that it shares the same first bits as path

--- a/packages/merkle-trees/src/types.nr
+++ b/packages/merkle-trees/src/types.nr
@@ -62,7 +62,13 @@ pub trait NonMembershipProver<T, K> {
      * @param matching_entry Contains (key, value) of a matching entry
      * @param siblings Contains array of siblings the matching_entry
      */
-    fn non_membership<let N: u32>(self, matching_entry: K, index: Field, siblings: [T; N]);
+    fn non_membership<let N: u32>(
+        self,
+        matching_entry: K,
+        queried_key: T,
+        index: Field,
+        siblings: [T; N],
+    );
 }
 
 pub trait Modifier<T, K> {

--- a/tests/Nargo.toml
+++ b/tests/Nargo.toml
@@ -4,9 +4,9 @@ type = "lib"
 authors = ["signorecello", "vplasencia"]
 
 [dependencies]
-bignum = { git = "https://github.com/noir-lang/noir-bignum", tag = "v0.8.3" }
+bignum = { git = "https://github.com/noir-lang/noir-bignum", tag = "v0.9.2" }
 lazytower = { path = "../packages/lazytower" }
 trees = { path = "../packages/merkle-trees" }
 ecdh = { path = "../packages/ecdh" }
 binary_merkle_root = { path = "../packages/binary-merkle-root" }
-poseidon = { git = "https://github.com/noir-lang/poseidon", tag = "v0.1.1" }
+poseidon = { git = "https://github.com/noir-lang/poseidon", tag = "v0.2.6" }

--- a/tests/src/mt/bignum.nr
+++ b/tests/src/mt/bignum.nr
@@ -4,7 +4,7 @@ use poseidon::poseidon2::Poseidon2::hash;
 use trees::merkle::{MerkleTree, Modifier, MT_Creator};
 
 fn hasher<let N: u32>(input: [BN254_Fq; N]) -> BN254_Fq {
-    let mut limbs: [Field] = &[];
+    let mut limbs: [Field] = @[];
     for i in 0..N {
         limbs = limbs.append(input[i].get_limbs().map(|limb| limb as Field));
     }

--- a/tests/src/smt/bignum.nr
+++ b/tests/src/smt/bignum.nr
@@ -4,7 +4,7 @@ use poseidon::poseidon2::Poseidon2::hash;
 use trees::sparse_merkle::{Modifier, NonMembershipProver, SMT_Creator, SparseMerkleTree};
 
 fn hasher<let N: u32>(input: [BN254_Fq; N]) -> BN254_Fq {
-    let mut limbs: [Field] = &[];
+    let mut limbs: [Field] = @[];
     for i in 0..N {
         limbs = limbs.append(input[i].get_limbs().map(|limb| limb as Field));
     }
@@ -93,7 +93,7 @@ fn test_sparse_merkle_tree_non_membership_bignum() {
         ]),
     );
 
-    smt.non_membership(matching_entry, 0x01, siblings);
+    smt.non_membership(matching_entry, BN254_Fq::from_limbs([0x01, 0x00, 0x00]), 0x01, siblings);
 }
 
 // #[test]

--- a/tests/src/smt/pedersen.nr
+++ b/tests/src/smt/pedersen.nr
@@ -30,7 +30,7 @@ fn test_verify_non_membership_proof() {
     let mut siblings: [Field; 254] = [0; 254];
     siblings[253] = 0x1891383341c9ba47346ab2cf7dfcf6ba42491d17f3fa692a5c1029732029aa53;
 
-    smt.non_membership(matching_entry, entry.0, siblings);
+    smt.non_membership(matching_entry, entry.0, entry.0, siblings);
 }
 
 #[test]
@@ -112,4 +112,22 @@ fn test_update() {
 
     smt.update(new_entry, old_entry, old_entry.0, siblings);
     assert(smt.root == big_tree_root);
+}
+
+#[test(should_fail)]
+fn test_false_non_membership_proof_fails() {
+    let root = 0x7ca084dd359e77ce4a7a683ccd717c45ecee547a73e73fd1a1cb62ec2a30961;
+    let smt = SparseMerkleTree::from(root, pedersen_hash, pedersen_hash);
+
+    let key = 0x03;
+    let entry = (key, 0x03);
+
+    let mut siblings: [Field; 254] = [0; 254];
+    siblings[252] = 0xe51bb5b5db9cc2c7dfd9c38ed5db39f784973f7235da39923a78793b28fe13a;
+    siblings[253] = 0x206456a6a1f0ee74ce95061dfbbc35ddc4ac3644988b324b5fe50e77215f1702;
+
+    // This entry IS in the tree (membership succeeds)
+    smt.membership(entry, key, siblings);
+    // Non-membership with the same key must fail
+    smt.non_membership(entry, key, key, siblings);
 }

--- a/tests/src/smt/poseidon2.nr
+++ b/tests/src/smt/poseidon2.nr
@@ -30,7 +30,7 @@ fn test_verify_non_membership_proof() {
     let mut siblings: [Field; 254] = [0; 254];
     siblings[253] = 0x2caff4d2bbd06504be02b53bf953596476bec9448d5a365c05daf1f39812f42;
 
-    smt.non_membership(matching_entry, entry.0, siblings);
+    smt.non_membership(matching_entry, entry.0, entry.0, siblings);
 }
 
 #[test]


### PR DESCRIPTION
## Description


non_membership function in [sparse_merkle.nr:41-49](https://github.com/zk-kit/zk-kit.noir/blob/main/packages/merkle-trees/src/sparse_merkle.nr#L41-L49) only verifies that `calculate_root(matching_entry, index, siblings) == self.root`. It never checks that the matching entry's key differs from the queried key. A malicious prover can use the actual entry at key K as the matching_entry with index = K, and the function accepts it as a valid non-membership proof
.

**To Reproduce**
Steps to reproduce the behavior:

1. Insert an entry with key K into the sparse Merkle tree
2. Call non_membership with index = K and matching_entry set to the actual entry at K
3. Provide valid siblings for the Merkle path
4. The function returns true,  falsely proving K is not in the tree

here is the testcase
```nr
use std::hash::pedersen_hash;
use trees::sparse_merkle::{
    MembershipProver, Modifier, NonMembershipProver, SMT_Creator, SparseMerkleTree,
};

#[test]
fn test_vulnerability_false_non_membership_proof() {
    let root = 0x7ca084dd359e77ce4a7a683ccd717c45ecee547a73e73fd1a1cb62ec2a30961;
    let smt = SparseMerkleTree::from(root, pedersen_hash, pedersen_hash);

    let key = 0x03;
    let entry = (key, 0x03);  // this entry IS in the tree

    let mut siblings: [Field; 254] = [0; 254];
    siblings[252] = 0xe51bb5b5db9cc2c7dfd9c38ed5db39f784973f7235da39923a78793b28fe13a;
    siblings[253] = 0x206456a6a1f0ee74ce95061dfbbc35ddc4ac3644988b324b5fe50e77215f1702;

    // both pass with same inputs - that's the bug
    smt.membership(entry, key, siblings);
    smt.non_membership(entry, key, siblings);
}

```
**Expected behavior**
non_membership function should reject the proof when the matching entry's key equals the queried key. A non-membership proof must demonstrate that a key does not exist in the tree.

Screenshots

**Additional context**
Add any other context about the problem here.



## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
<!-- Feel free to remove this section if you will not use it. -->

## Checklist

<!-- Please check if the PR fulfills these requirements. -->

- [x] I have read and understand the [contributor guidelines](https://github.com/privacy-scaling-explorations/zk-kit.noir/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/privacy-scaling-explorations/zk-kit.noir/blob/main/CODE_OF_CONDUCT.md).
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have run `bun check` without getting any errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

> [!IMPORTANT]
> We do not accept pull requests for minor grammatical fixes (e.g., correcting typos, rewording sentences) or for fixing broken links, unless they significantly improve clarity or functionality. These contributions, while appreciated, are not a priority for merging. If you notice any of these issues, please create a [GitHub Issue](https://github.com/privacy-scaling-explorations/zk-kit.noir/issues/new?template=BLANK_ISSUE) to report them so they can be properly tracked and addressed.
