### PR TITLE
fix(merkle-trees): track the first sibling explicitly in calculate_two_roots

### DIFF
--- a/packages/merkle-trees/src/sparse_merkle.nr
+++ b/packages/merkle-trees/src/sparse_merkle.nr
@@ -178,6 +178,8 @@ where
         // root_without_leaf is a container for hashes to derive the root node for the tree that
         // doesn't include the entry
         let mut root_without_leaf = T::default();
+        // whether the first nonzero sibling has been seeded into root_without_leaf
+        let mut found_first = false;
         // iterate over the levels of the tree from bottom to top
         for i in 0..hash_path.len() {
             let sibling = hash_path[i];
@@ -187,21 +189,21 @@ where
             // and starting from each SUBSEQUENT iteration it is hashed with its sibling and the resulting hash
             // again stored in the container until the root is reached
             if sibling != T::default() {
-                if (i > 0) & (hash_path[i - 1] == T::default()) {
-                    root_without_leaf = hash_path[i];
-                }
-
                 if index_bits[i] != 0 {
                     root_with_leaf = (self.hasher)([sibling, root_with_leaf]);
-                    if (root_without_leaf != sibling) {
+                    if found_first {
                         root_without_leaf = (self.hasher)([sibling, root_without_leaf]);
                     }
                 } else {
                     root_with_leaf = (self.hasher)([root_with_leaf, sibling]);
-
-                    if (root_without_leaf != sibling) {
+                    if found_first {
                         root_without_leaf = (self.hasher)([root_without_leaf, sibling]);
                     }
+                }
+
+                if !found_first {
+                    root_without_leaf = sibling;
+                    found_first = true;
                 }
             }
         }

--- a/tests/src/smt/pedersen.nr
+++ b/tests/src/smt/pedersen.nr
@@ -1,6 +1,6 @@
 use std::hash::pedersen_hash;
 use trees::sparse_merkle::{
-    MembershipProver, Modifier, NonMembershipProver, SMT_Creator, SparseMerkleTree,
+    Calculator, MembershipProver, Modifier, NonMembershipProver, SMT_Creator, SparseMerkleTree,
 };
 
 #[test]
@@ -130,4 +130,19 @@ fn test_false_non_membership_proof_fails() {
     smt.membership(entry, key, siblings);
     // Non-membership with the same key must fail
     smt.non_membership(entry, key, key, siblings);
+}
+
+#[test]
+fn test_sparse_merkle_tree_two_roots_folds_every_sibling() {
+    let root = 0x7ca084dd359e77ce4a7a683ccd717c45ecee547a73e73fd1a1cb62ec2a30961;
+    let smt = SparseMerkleTree::from(root, pedersen_hash, pedersen_hash);
+
+    // a node at level 100 that no honest path would contain, plus the real root on top
+    let mut path: [Field; 254] = [0; 254];
+    path[100] = pedersen_hash([0x200000000000000000000000000000000000000, 999999, 0]);
+    path[253] = root;
+
+    // every nonzero sibling is folded, so a spurious node cannot leave the old root intact
+    let (without_leaf, _with_leaf) = smt.calculate_two_roots((0, 10), 0, path);
+    assert(without_leaf != root);
 }


### PR DESCRIPTION
`calculate_two_roots` needs to know whether the first nonzero sibling has already been promoted into
`root_without_leaf`. It currently works that out twice, once from `hash_path[i - 1] == 0` and once from
`root_without_leaf != sibling`, and neither is equivalent to the thing it is standing in for. The positional
one fires again at every hole in the path and resets the accumulator; the value one is satisfiable by
choosing a sibling equal to the accumulator. Either way a node can sit in the path without being folded in,
and `add`'s `assert(old == self.root)` still passes.

This replaces both with a flag that says what is actually meant. It also drops the `hash_path[i - 1]` read,
which underflows at `i == 0`.

Closes #73.

Tested on nargo 1.0.0-beta.19 (the toolchain in CI): the full suite passes, 41/41 including the regression test added here. Reverting just the source change makes that test fail.