### PR TITLE
fix(merkle-trees): seed root_without_leaf by index instead of by value

### DIFF
--- a/packages/merkle-trees/src/merkle.nr
+++ b/packages/merkle-trees/src/merkle.nr
@@ -112,9 +112,6 @@ where
 
         // iterate over the levels of the tree from bottom to top
         for i in 0..hash_path.len() {
-            if i == 0 {
-                root_without_leaf = hash_path[i];
-            }
             let sibling = hash_path[i];
             // After the first sibling is found, the processes are started to calculate the two root nodes.
             // The calulcation of the root node that includes the entry is comparable to `calculate_root`.
@@ -123,14 +120,18 @@ where
             // again stored in the container until the root is reached
             if index_bits[i] == 0 {
                 root_with_leaf = (self.hasher)([root_with_leaf, sibling]);
-                if (root_without_leaf != sibling) {
+                if i != 0 {
                     root_without_leaf = (self.hasher)([root_without_leaf, sibling]);
                 }
             } else {
                 root_with_leaf = (self.hasher)([sibling, root_with_leaf]);
-                if (root_without_leaf != sibling) {
+                if i != 0 {
                     root_without_leaf = (self.hasher)([sibling, root_without_leaf]);
                 }
+            }
+
+            if i == 0 {
+                root_without_leaf = sibling;
             }
         }
         (root_without_leaf, root_with_leaf)

--- a/tests/src/mt/poseidon2.nr
+++ b/tests/src/mt/poseidon2.nr
@@ -57,3 +57,12 @@ fn test_merkle_tree_update() {
             ),
     );
 }
+
+#[test(should_fail)]
+fn test_merkle_tree_add_rejects_copath_of_repeated_roots() {
+    let old_root = 0x21447efbbddb57d6fc5ad24d906388492e82c44e5160425258dd4ea995e3a06e;
+    let mut mt = MerkleTree::from(old_root, |h| hash(h, 2));
+    // passing the old root as every sibling used to satisfy the old-root assert
+    // without proving a co-path
+    mt.add(0x99, 0x00, [old_root, old_root]);
+}


### PR DESCRIPTION
The `root_without_leaf != sibling` guard is meant to skip the hash on the first iteration, which the comment
and the `if i == 0` seed two lines above already say. Written as a value comparison it is true at `i == 0`
by coincidence and satisfiable at every other level by passing a sibling equal to the accumulator. A co-path
of repeated old roots therefore keeps the accumulator pinned and `assert(old == self.root)` passes without a
co-path being proven.

This uses the index check the code was already reaching for.

Closes #74.

Tested on nargo 1.0.0-beta.19 (the toolchain in CI): the full suite passes, 41/41 including the regression test added here. Reverting just the source change makes that test fail.