### PR TITLE
fix: allow create-tag when README already has the target version

### DIFF
--- a/scripts/create-tag.ts
+++ b/scripts/create-tag.ts
@@ -14,22 +14,25 @@ const readmePath = `packages/${packageName}/README.md`
 
 try {
   const readme = readFileSync(readmePath, 'utf8')
-  // Bump every `tag = "<package>-vX.Y.Z"` in the install snippet.
-  const updated = readme.replace(
-    new RegExp(`tag = "${packageName}-v[0-9]+\\.[0-9]+\\.[0-9]+"`, 'g'),
-    `tag = "${tag}"`,
-  )
+  const tagPattern = `tag = "${packageName}-v[0-9]+\\.[0-9]+\\.[0-9]+"`
 
-  if (updated === readme) {
+  if (!new RegExp(tagPattern).test(readme)) {
     console.error(`❌ No install snippet with a "${packageName}-v..." tag found in ${readmePath}`)
     process.exit(1)
   }
 
-  writeFileSync(readmePath, updated)
+  // Bump every `tag = "<package>-vX.Y.Z"` in the install snippet.
+  const updated = readme.replace(new RegExp(tagPattern, 'g'), `tag = "${tag}"`)
 
-  execSync(`git add ${readmePath}`, { stdio: 'inherit' })
-  // NO_HOOK=1 skips the interactive `czg` prepare-commit-msg hook.
-  execSync(`NO_HOOK=1 git commit -m "docs(${packageName}): update install version to ${version}"`)
+  // Already at this version (e.g. a first release) — nothing to commit.
+  if (updated !== readme) {
+    writeFileSync(readmePath, updated)
+
+    execSync(`git add ${readmePath}`, { stdio: 'inherit' })
+    // NO_HOOK=1 skips the interactive `czg` prepare-commit-msg hook.
+    execSync(`NO_HOOK=1 git commit -m "docs(${packageName}): update install version to ${version}"`)
+  }
+
   execSync(`git tag ${tag}`, { stdio: 'inherit' })
 
   console.log(`✅ Updated ${readmePath} and created git tag: ${tag}`)


### PR DESCRIPTION
<!-- Please refer to our CONTRIBUTING documentation for any questions on submitting a pull request. -->
<!-- Provide a general summary of your changes in the Title above. -->

## Description

<!-- Describe your changes in detail. -->
<!-- You may want to answer some of the following questions: -->
<!-- What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...) -->
<!-- What is the current behavior?** (You can also link to an open issue here) -->
<!-- What is the new behavior (if this is a feature change)? -->
<!-- Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?) -->

This PR allows create-tag when README already has the target version.

## Checklist

<!-- Please check if the PR fulfills these requirements. -->

- [x] I have read and understand the [contributor guidelines](https://github.com/zk-kit/zk-kit.noir/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/zk-kit/zk-kit.noir/blob/main/CODE_OF_CONDUCT.md).
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have run `bun check` without getting any errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

> [!IMPORTANT]
> We do not accept pull requests for minor grammatical fixes (e.g., correcting typos, rewording sentences) or for fixing broken links, unless they significantly improve clarity or functionality. These contributions, while appreciated, are not a priority for merging. If you notice any of these issues, please create a [GitHub Issue](https://github.com/zk-kit/zk-kit.noir/issues/new?template=BLANK_ISSUE) to report them so they can be properly tracked and addressed.
